### PR TITLE
Add `azure_` prefix to all scraped metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func (c *Collector) extractMetrics(ch chan<- prometheus.Metric, rm resourceMeta,
 		if rm.metricNamespace != "" {
 			metricName = strings.ToLower(rm.metricNamespace + "_" + metricName)
 		}
+		metricName = "azure_" + metricName
 		metricName = invalidMetricChars.ReplaceAllString(metricName, "_")
 
 		if len(value.Timeseries) > 0 {


### PR DESCRIPTION
## What

SSIA. Common metrics already have `azure_` prefix as below;

- https://github.com/umatare5/azure_metrics_exporter/blob/5447b6c5951d8527b33841b1e066db55fa2d9c26/main.go#L31
- https://github.com/umatare5/azure_metrics_exporter/blob/5447b6c5951d8527b33841b1e066db55fa2d9c26/main.go#L122

## Why

Manage azure_metrics_exporter's metrics uniquely in Prometheus.