### PR TITLE
Add `azure_` prefix to scraped metrics not starts at `azure_`

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,8 +76,10 @@ func (c *Collector) extractMetrics(ch chan<- prometheus.Metric, rm resourceMeta,
 		if rm.metricNamespace != "" {
 			metricName = strings.ToLower(rm.metricNamespace + "_" + metricName)
 		}
-		metricName = "azure_" + metricName
 		metricName = invalidMetricChars.ReplaceAllString(metricName, "_")
+		if !strings.HasPrefix(metricName, "azure_") {
+			metricName = "azure_" + metricName
+		}
 
 		if len(value.Timeseries) > 0 {
 			metricValue := value.Timeseries[0].Data[len(value.Timeseries[0].Data)-1]


### PR DESCRIPTION
## What

SSIA.

- Upstream: https://github.com/umatare5/azure_metrics_exporter/pull/4

## Why

`azure.vm.linux.guestmetrics` is converted to `azure_azure_vm_linux_guestmetrics`.